### PR TITLE
Fix the tsconfig.json and Add Comment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import typia, { Primitive } from "typia";
 
 import { SGlobal } from "./SGlobal";
 import { BbsArticleService } from "./services/BbsArticleService";
+/// INSERT IMPORT HERE
+
 
 const getPromptHistories = async (
   id: string,
@@ -43,6 +45,7 @@ const main = async (): Promise<void> => {
           application: typia.llm.application<BbsArticleService, "chatgpt">(),
           execute: new BbsArticleService(),
         },
+        /// INSERT CONTROLLER HERE
       ],
       histories:
         // check {id} parameter

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,5 +102,7 @@
       }
     ],
     "strictNullChecks": true
-  }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description
- the `npm run build && npm run start` command did not work. because of the `tsconfig.json`.
  - so I add `include` and `exclude` options at the end of `tsconfig.json`.

- Add comment `/// INSERT IMPORT HERE` and `/// INSERT CONTROLLER HERE`
  - plan to replace the comments with the generation code to insert the CLI generation code.